### PR TITLE
Fix minimal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ To use the tutorial, create a new workspace in your config, pointing to the gtd 
 
 ```lua
 require("neorg").setup({
+  load = {
+    ["core.defaults"] = {},
     ["core.norg.dirman"] = {
       config = {
         workspaces = {
@@ -24,6 +26,7 @@ require("neorg").setup({
         workspace = "example_gtd",
       },
     },
+  }
 })
 ```
 


### PR DESCRIPTION
The minimal config provided in the README does not work. Specifically, it is missing the `load` argument. Furthermore `core.defaults` needs to be included in order to make the keybindings referenced in `index.norg` work.